### PR TITLE
#155: Invalid QR Code shouldn't freeze the app

### DIFF
--- a/src/pages/Login/LoginRequest.js
+++ b/src/pages/Login/LoginRequest.js
@@ -207,7 +207,6 @@ export default (props) => {
     info?.request?.loginDomain || info?.payload?.context || 'Unidentified'
   const logoUrl = info.request?.logoUrl
   const appName = info.request?.context
-  console.log('expiry - Date.now()', expiry - Date.now())
   const expired = expiry <= Date.now()
   const timeToExpire = moment(expiry).format('YYYY MMM DD [at] HH:mm')
   const expiryText = expired


### PR DESCRIPTION
close #155 

- Case 1: Scan a QR Code that was already scanned
![IMG_E12605A8DAD4-1](https://user-images.githubusercontent.com/12524553/144597057-c56eaa88-bcfc-48f3-9b69-0dc7e567e6dc.jpeg)

- Case 2: Scan an expired QR Code
![IMG_74DC9D1AE07A-1](https://user-images.githubusercontent.com/12524553/145208240-eb340141-6087-4a48-99c3-c58fdd339763.jpeg)

