### PR TITLE
Fix invalid accounts list after log out

### DIFF
--- a/src/pages/Dashboard/SeedPhraseRemindView.tsx
+++ b/src/pages/Dashboard/SeedPhraseRemindView.tsx
@@ -24,6 +24,10 @@ function SeedPhraseRemindView(props: SeedPhraseRemindViewProps) {
 
   useEffect(() => {
     async function checkReminder() {
+      if (!selectedAccount) {
+        return
+      }
+
       if (selectedAccount?.seedPhraseReminder?.backedup) {
         dispatch(setShowSeedPhraseReminder(false))
         return


### PR DESCRIPTION
There is an empty account instance after logout, it creates a wrong UI display on accounts list