### PR TITLE
Fix TextEncoder not found issue on Android

### DIFF
--- a/src/api/AccountManager.ts
+++ b/src/api/AccountManager.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line simple-import-sort/imports
 import * as Sentry from '@sentry/react-native'
-import { AutoAccount } from '@verida/account-node'
 import { Client, Context, EnvironmentType } from '@verida/client-rn'
+import { AutoAccount } from '@verida/account-node'
 import Vault from '@verida/vault-common'
 import WalletUtils from '@verida/wallet-utils'
 import { utils } from 'ethers'


### PR DESCRIPTION
Import order in `AccountManager` caused TextEncoder polyfill to be missing / overrided on Android. I turned off this temporarily until we find out a better solution.