### PR TITLE
Show Android splash screen on starting the app

### DIFF
--- a/android/app/src/main/java/io/verida/vault/MainActivity.java
+++ b/android/app/src/main/java/io/verida/vault/MainActivity.java
@@ -11,14 +11,11 @@ import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
 public class MainActivity extends ReactActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    // SplashScreen.show(...) has to be called after super.onCreate(...)
-    // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
-    // SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
-  }
-
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
+    }
 
     /**
      * Returns the name of the main component registered from JavaScript.


### PR DESCRIPTION
Changes:
- Show Android splash screen on starting the app

Issue: https://github.com/verida/vault-mobile/issues/335