### PR TITLE
#386: Configure compliance for AppstoreConnect

### DIFF
--- a/ios/myApp/Info.plist
+++ b/ios/myApp/Info.plist
@@ -44,7 +44,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR Code</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>This app uses bio authentication to secure user's private info</string>
+	<string>This app uses bio authentication to secure user&apos;s private info</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Allow user to track their location</string>
 	<key>NSPhotoLibraryUsageDescription</key>
@@ -92,6 +92,8 @@
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
As discussed with @nick-verida, our app is using encryption but it is exempt.