### PR TITLE
#375: Fix authorization issue of register device token request after creating new account

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -203,6 +203,7 @@ export async function unRegisterRemoteNotification(token: string) {
 
     const axiosInstance = await getAxios()
     await axiosInstance.post(`${notificationServerUrl}/unregister`, body)
+    axiosAuthPassword = undefined
   } catch (e) {
     Sentry.captureException(e)
   }


### PR DESCRIPTION
After logging out, the authorization header needs to be created again when a new account is created.