### PR TITLE
bug-fix/479-fix-remove-wallets-running-on-each-app-launch

### DIFF
--- a/src/api/AccountManager.ts
+++ b/src/api/AccountManager.ts
@@ -281,7 +281,10 @@ class AccountManager {
       // save to storage..
       await SecureStore.setItemAsync(
         WALLETS_STORAGE_KEY,
-        JSON.stringify(userGeneratedWallets)
+        JSON.stringify({
+          seedPhrase: userHDWalletMnemonic,
+          accounts: userGeneratedWallets,
+        })
       )
     } catch (e) {
       Sentry.captureException(e)
@@ -297,6 +300,7 @@ class AccountManager {
       )
 
       const HDwallets = await datastore?.getMany()
+
       if (HDwallets) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -310,7 +314,7 @@ class AccountManager {
         // save to storage..
         await SecureStore.setItemAsync(
           WALLETS_STORAGE_KEY,
-          JSON.stringify(wallets)
+          JSON.stringify({ seedPhrase: mnemonic, accounts: wallets })
         )
       }
     } catch (e) {


### PR DESCRIPTION
<img width="478" alt="Screen Shot 2022-04-22 at 9 38 17 PM" src="https://user-images.githubusercontent.com/4365774/165080529-b0a0e20b-8f61-46e1-820f-0ec428ea0776.png">

REMOVE_USER_WALLETS and SET_USER_WALLETS was firing on each launch instead of just once, this was related to state migration that I did after NEAR support was added