### PR TITLE
Increase max number of same host http connection to 64

### DIFF
--- a/android/app/src/main/java/io/verida/vault/CustomNetworkModule.java
+++ b/android/app/src/main/java/io/verida/vault/CustomNetworkModule.java
@@ -1,0 +1,34 @@
+package io.verida.vault;
+
+import com.facebook.react.modules.network.OkHttpClientFactory;
+import com.facebook.react.modules.network.ReactCookieJarContainer;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+
+class CustomNetworkModule implements OkHttpClientFactory {
+    static final int MAX_REQUEST_NUMBER_PER_HOST = 64;
+
+    public OkHttpClient createNewNetworkModuleClient() {
+        return new OkHttpClient.Builder()
+                .cookieJar(new ReactCookieJarContainer())
+                .dispatcher(createDispatcher())
+                .connectionPool(createConnectionPool())
+                .build();
+    }
+
+    private static Dispatcher createDispatcher() {
+        final Dispatcher dispatcher = new Dispatcher(Executors.newCachedThreadPool());
+        dispatcher.setMaxRequests(MAX_REQUEST_NUMBER_PER_HOST);
+        dispatcher.setMaxRequestsPerHost(MAX_REQUEST_NUMBER_PER_HOST);
+        return dispatcher;
+    }
+
+    private static ConnectionPool createConnectionPool() {
+        return new ConnectionPool(MAX_REQUEST_NUMBER_PER_HOST, 10000, TimeUnit.MILLISECONDS);
+    }
+}

--- a/android/app/src/main/java/io/verida/vault/MainApplication.java
+++ b/android/app/src/main/java/io/verida/vault/MainApplication.java
@@ -13,6 +13,7 @@ import dog.craftz.sqlite_2.RNSqlite2Package;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import io.verida.vault.generated.BasePackageList;
@@ -66,6 +67,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    OkHttpClientProvider.setOkHttpClientFactory(new CustomNetworkModule());
     SoLoader.init(this, /* native exopackage */ false);
 
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());


### PR DESCRIPTION
# Why
PouchDB 2way-sync relies a lot on long-poll HTTP requests, and Vault has a large number of databases around 6+. At peak, there are more than 5 connections to the same host at a time that exceeds the default max number of the same host connection config in Android okhhtp library https://square.github.io/okhttp/4.x/okhttp/okhttp3/-dispatcher/max-requests-per-host/ used by React Native core for Android network.

## Solution
Increase the max number of same host connections to 64(will revisit and do more thoughtful research on this number) did solve the issue.



