### PR TITLE
Add build version

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -9,6 +9,7 @@ declare module "react-native-config" {
     INFURA_API_KEY: string
     SENTRY_ENVIRONMENT: string
     BITRISE_TRIGGERED_WORKFLOW_TITLE: string
+    DEPLOY_ENVIRONMENT: string
   }
   const BuildConfig: Env
   export default BuildConfig

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -80,7 +80,7 @@ export default (props) => {
   const networks = useSelector((state) => state.main.networks)
   const modifiedGeneralList = [...generalList]
   const versionText = `Verida Vault ${capitalize(
-    Config.BITRISE_TRIGGERED_WORKFLOW_TITLE
+    Config.BITRISE_TRIGGERED_WORKFLOW_TITLE || Config.DEPLOY_ENVIRONMENT
   )} v${getVersion()}(${getBuildNumber()})`
 
   if (!isEmpty(networks)) {

--- a/src/wallet-connect/helpers/utilities.ts
+++ b/src/wallet-connect/helpers/utilities.ts
@@ -4,7 +4,8 @@ import Config from 'react-native-config'
 import { SUPPORTED_CHAINS } from '../constants'
 import { IChainData } from '../types'
 
-const { INFURA_API_KEY } = Config
+// TODO: hardcode just to have a running build first, fix Bitrise .env config
+const { INFURA_API_KEY = '6e4bf0201647493e93c9eea13b70bd4d' } = Config
 
 export function payloadId(): number {
   const datePart: number = new Date().getTime() * Math.pow(10, 3)


### PR DESCRIPTION
This adds a build version as requested in https://github.com/verida/vault-mobile/issues/530
The build version should be either in .env file or will be picked up from Bitrise.

![Screen Shot 2022-07-19 at 4 42 20 PM](https://user-images.githubusercontent.com/10988386/179666253-02579cf8-7acb-4128-9b11-b4fb83ef8e80.png)
