### PR TITLE
Fix/693 length of decimal in polygon testnest

### DIFF
--- a/src/components/Tokens/TokenBanner.js
+++ b/src/components/Tokens/TokenBanner.js
@@ -43,7 +43,7 @@ export default ({
           </View>
         )}
         <Text style={styles.amount}>
-          {label ? `${quantity.toFixed(3)} ${symbol}` : `$${amount.toFixed(2)}`}
+          {label ? `${quantity.toFixed(2)} ${symbol}` : `$${amount.toFixed(2)}`}
         </Text>
         <Text style={styles.amountLabel}>
           {label ? `≈ $${amount.toFixed(2)}` : `Total  Balance`}


### PR DESCRIPTION
Closes https://github.com/verida/wallet-provider/issues/119

- Used the `.toFixed()` to display consistent decimal place for token.