### PR TITLE
Change Walletprovider api url

### DIFF
--- a/src/wallet/helpers/api.js
+++ b/src/wallet/helpers/api.js
@@ -27,5 +27,5 @@ export const nearIndexerApi = create({
 })
 
 export const walletProviderApi = create({
-  baseURL: 'https://walletprovider-dev.tn.verida.tech',
+  baseURL: 'https://walletprovider.tn.verida.tech',
 })


### PR DESCRIPTION
- Changed wallet provider API URL to  https://walletprovider.tn.verida.tech


 Closes #754