### PR TITLE
Fix/1016 - Handle potential null message in Polygon ID `parseMessage`

### DIFF
--- a/src/features/polygonid/utils/message.ts
+++ b/src/features/polygonid/utils/message.ts
@@ -15,7 +15,7 @@ function checkParsedMessage(
   parsedMessage: Record<string, unknown>,
   originalMessage: string
 ) {
-  // Merely checking the parsedMessage is not null/undefined/empty
+  // For now, merely checking the parsedMessage is not null/undefined/empty. Could add stronger checks.
   if (parsedMessage) {
     return
   }


### PR DESCRIPTION
In very few case, the parsed message in Polygon ID deep link were `null` or `undefined`

### 💭 What's changed?

- Added a check before using the message, throwing an error and sending the information to Sentry

### 🧪 How to test these changes?

-

### 😨 Anything to be aware of?

-
