### PR TITLE
Add timeout on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Check and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### 💭 What's changed?

Added a 30 minutes timeout on the CI workflow to avoid spending to much credit if something is stuck. At time of this change, the workflow is usually around 7 minutes, so 30 minutes is reasonable.

### 🧪 How to test these changes?

-

### 😨 Anything to be aware of?

- 