### PR TITLE
Fix crypto wallet not loaded following importing an identity

### DIFF
--- a/src/api/AccountManager.ts
+++ b/src/api/AccountManager.ts
@@ -603,14 +603,14 @@ class AccountManager extends EventEmitter {
       await this.restoreUserWallet(true)
       DataConnectorsManager.emit('logout', null)
 
+      store.dispatch(setSelectedAccount(this.selectedAccount))
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const name = await this.vault?.profiles.public.get('name')
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const avatar = await this.vault?.profiles.public.get('avatar')
-
-      store.dispatch(setSelectedAccount(this.selectedAccount))
       setTimeout(() => {
         store.dispatch(
           setSwitchAccountToast({
@@ -681,6 +681,7 @@ class AccountManager extends EventEmitter {
       await this.connect(true)
       store.dispatch(setSelectedAccount(this.selectedAccount))
       store.dispatch(addAccount(this.selectedAccount))
+      await this.restoreUserWallet(true)
 
       return this.selectedAccount
     } catch (e) {


### PR DESCRIPTION
### 💭 What's changed?

- Called the `AccountManager#restoreUserWallet` in the `AccountManager#importAccount`

### 🧪 How to test these changes?

- Create a new Identity
- Notice the selected crypto wallet (by default the "Multi Chain Wallet") as well as the list of crypto wallets (click on the header)
- Import an existing Identity (such as the Devnet/Testnet Identity from Bitwarden)
- Notice the selected crypto wallet (by default the "Multi Chain Wallet") as well as the list of crypto wallets (click on the header) => They should be from the imported Identity, not from the previous one

### 😨 Anything to be aware of?

- Nope
