### PR TITLE
Remove advertising id permission on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+  <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:largeHeap="true" android:theme="@style/AppTheme" android:networkSecurityConfig="@xml/network_security_config">
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>


### PR DESCRIPTION
### 💭 What's changed?

- Explicitly remove permission in AndroidManifest

### 😨 Anything to be aware of?

- We were not declaring that permission ourselves, but a third-party (possibly Firebase) was doing it.
- See [Google Play note](https://developers.google.com/android/guides/releases#september_22_2021_2) on how we can explicitly remove it
