### PR TITLE
Fix message set to read even if action failed

### DIFF
--- a/src/api/VaultCommon/managers/inbox.ts
+++ b/src/api/VaultCommon/managers/inbox.ts
@@ -38,17 +38,18 @@ export class InboxManager {
     action: keyof DataAction,
     payload: any
   ) {
+    logger.debug('Handling inbox item action', { inboxEntry, action, payload })
+    logger.debug('Initializing messaging')
     await this.init()
+    logger.debug('Messaging initialized')
     const inbox = await this.messaging.getInbox()
 
+    logger.debug('Inbox entry status', { status: inboxEntry.data.status })
     if (inboxEntry.data.status) {
       throw new Error('Data has already been set to ' + inboxEntry.data.status)
     }
 
     inboxEntry.data.status = action
-    inboxEntry.read = true
-
-    await inbox.privateInbox.save(inboxEntry)
 
     const Middleware = DataHandler[inboxEntry.type]
     if (!Middleware) {
@@ -66,7 +67,13 @@ export class InboxManager {
       inboxEntry,
       payload
     )
-    return MiddlewareInstance[action]()
+
+    logger.debug('Executing action')
+    await MiddlewareInstance[action]()
+
+    inboxEntry.read = true
+    logger.debug('Saving inbox entry', { inboxEntry })
+    await inbox.privateInbox.save(inboxEntry)
   }
 
   public async fetchLatest(filter = {}, options = {}) {

--- a/src/api/VaultCommon/managers/inbox/Request.ts
+++ b/src/api/VaultCommon/managers/inbox/Request.ts
@@ -1,10 +1,15 @@
+import { Logger } from 'features/telemetry'
+
 import { InboxResponse, InboxType } from '../../interfaces/inbox/Inbox'
 import { DataAction } from './DataAction'
+
+const logger = new Logger('InboxDataRequest')
 
 const MSG = 'Send you the requested data'
 
 export class Request extends DataAction {
   async accept() {
+    logger.debug('Accepting data request')
     const dataRequest = this.inboxEntry.data
     const { did, context } = this.inboxEntry.sentBy
 
@@ -20,9 +25,11 @@ export class Request extends DataAction {
       response.data = [foundData]
     }
 
+    logger.debug('Sending data response')
     await this.messaging.send(did, InboxType.DATA_SEND, response, MSG, {
       recipientContextName: context,
     })
+    logger.debug('Data response sent')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
### 💭 What's changed?

- Move saving the inbox entry (with a `read` state) after the success of the action. Used to be saved before, so if the action failed it was not possible to try again because the message was already `read`

### 🧪 How to test these changes?

-

### 😨 Anything to be aware of?

-
