### PR TITLE
fix: fix react-native-screens causes crashes on Android

### DIFF
--- a/android/app/src/main/java/io/verida/vault/MainActivity.java
+++ b/android/app/src/main/java/io/verida/vault/MainActivity.java
@@ -15,7 +15,8 @@ public class MainActivity extends ReactActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         setTheme(R.style.AppTheme);
-        super.onCreate(savedInstanceState);
+        super.onCreate(null);
+        
         SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
     }
 


### PR DESCRIPTION
### 💭 What's changed?
Issue: https://play.google.com/console/u/0/developers/5193719262594440827/app/4972638642314741687/vitals/crashes/5322aa514a2c9308c82f3120cc4f1e8f/details?isUserPerceived=true&badBehaviorDeviceMetrics=BAD_BEHAVIOR_DEVICE_METRIC_USER_PERCEIVED_CRASHES&days=28

- Hotfix for the crash issue happened recently on Android related to react-native-screen lib

**Stacktrace**
```
Exception java.lang.RuntimeException: Unable to start activity ComponentInfo{io.verida.vault/io.verida.vault.MainActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.swmansion.rnscreens.ScreenStackFragment: calling Fragment constructor caused an exception
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3897)
  at android.app.ActivityThread.handleLaunchActivity (ActivityThread.java:4043)
  at android.app.servertransaction.LaunchActivityItem.execute (LaunchActivityItem.java:101)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2437)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8294)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1028)
Caused by androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.swmansion.rnscreens.ScreenStackFragment: calling Fragment constructor caused an exception
  at androidx.fragment.app.Fragment.instantiate (Fragment.java:631)
  at androidx.fragment.app.FragmentContainer.instantiate (FragmentContainer.java:57)
  at androidx.fragment.app.FragmentManager$3.instantiate (FragmentManager.java:483)
  at androidx.fragment.app.FragmentStateManager.<init> (FragmentStateManager.java:85)
  at androidx.fragment.app.FragmentManager.restoreSaveState (FragmentManager.java:2728)
  at androidx.fragment.app.FragmentController.restoreSaveState (FragmentController.java:198)
  at androidx.fragment.app.FragmentActivity$2.onContextAvailable (FragmentActivity.java:149)
  at androidx.activity.contextaware.ContextAwareHelper.dispatchOnContextAvailable (ContextAwareHelper.java:99)
  at androidx.activity.ComponentActivity.onCreate (ComponentActivity.java:322)
  at androidx.fragment.app.FragmentActivity.onCreate (FragmentActivity.java:273)
  at com.facebook.react.ReactActivity.onCreate (ReactActivity.java:45)
  at io.verida.vault.MainActivity.onCreate (MainActivity.java:18)
  at android.app.Activity.performCreate (Activity.java:8538)
  at android.app.Activity.performCreate (Activity.java:8502)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1437)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3878)
Caused by java.lang.reflect.InvocationTargetException:
  at java.lang.reflect.Constructor.newInstance0
  at java.lang.reflect.Constructor.newInstance (Constructor.java:343)
  at androidx.fragment.app.Fragment.instantiate (Fragment.java:613)
Caused by java.lang.IllegalStateException: Screen fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-<US_SOCIAL_SECURITY_NUMBER> to properly configure your main activity.
  at com.swmansion.rnscreens.ScreenFragment.<init> (ScreenFragment.kt:54)
  at com.swmansion.rnscreens.ScreenStackFragment.<init> (ScreenStackFragment.kt:35)
```

**Solution**
https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067

**TODO:**
- [ ] I will need to create an emulator(Android 13) and try to reproduce and confirm the issue is fixed
