### PR TITLE
Ignore non-error reported to Sentry

### DIFF
--- a/src/features/telemetry/utils/sentry.ts
+++ b/src/features/telemetry/utils/sentry.ts
@@ -25,5 +25,17 @@ export function initSentry() {
     ignoreErrors: [
       // TODO: Add errors to ignore in Sentry
     ],
+    beforeSend(event, hint) {
+      if (
+        hint?.originalException &&
+        !(hint.originalException instanceof Error)
+      ) {
+        // Not reporting event that are not instances of Error
+        // We may be missing on some issues though
+        return null
+      }
+
+      return event
+    },
   })
 }


### PR DESCRIPTION
### 💭 What's changed?

- Implemented the `beforeSend` in Sentry configuration to check if the reported event is an actual error

### 🧪 How to test these changes?

-

### 😨 Anything to be aware of?

-
