### PR TITLE
Fix wrong native currency balances on mainnet

### DIFF
--- a/src/features/cryptoWallet/utils/chainMetadataToAggregateWalletBannerBalance.ts
+++ b/src/features/cryptoWallet/utils/chainMetadataToAggregateWalletBannerBalance.ts
@@ -1,3 +1,4 @@
+import BigDecimal from 'bignumber.js'
 import { ChainId, ChainIdParams } from 'caip'
 import { BigNumber } from 'ethers'
 import { ChainMetadata } from 'features/caip'
@@ -10,6 +11,7 @@ import {
   CryptoWalletBalances,
 } from '../@types'
 import { chainMetadataToMaybeValuation } from './chainMetadataToMaybeValuation'
+import { isNativeToken } from './isNativeToken'
 
 // Converts a ChainMetadata into an equivalent AggregateWalletBannerBalance.
 // Specifically, this takes a raw chain declaration and determines the balance
@@ -38,6 +40,14 @@ export function chainMetadataToAggregateWalletBannerBalance({
     reference,
   }
 
+  const maybeBalanceFromWalletProvider = balanceByChainResults
+    .filter(
+      (e) =>
+        namespace === e.asset.chainId.namespace &&
+        reference === e.asset.chainId.reference
+    )
+    .find((e) => isNativeToken(e.asset))
+
   // Where defined, these balances are split across all of the currently
   // active accounts for the given chain. Since we are looking at the
   // aggregate balance, we merely add these together.
@@ -50,7 +60,12 @@ export function chainMetadataToAggregateWalletBannerBalance({
         .reduce((b: BigNumber, e: string) => b.add(e), BigNumber.from('0'))
     : BigNumber.from('0')
 
-  const balance = totalBalance.toString() as `${number}`
+  // FIXME: The balance coming directly from the RPCs (cryptoWalletBalances) seem to be '0' on mainnet (ethereum and polygon), so we are using the balance from the wallet provider (maybeBalanceFromWalletProvider) as a fallback. This is a temporary fix, and we should investigate why the balance is '0' on mainnet.
+  const balance = maybeBalanceFromWalletProvider?.balance
+    ? (`${new BigDecimal(maybeBalanceFromWalletProvider.balance).multipliedBy(
+        new BigDecimal(10).pow(decimals)
+      )}` as `${number}`)
+    : (totalBalance.toString() as `${number}`)
 
   return {
     resource: chainId,


### PR DESCRIPTION
### 💭 What's changed?

- Use Wallet Provider balances instead of the 

### 🧪 How to test these changes?

- Add a watched wallet on Ethereum an Polygon mainnets and check their balances are correct (add an address with non-null balance for the native currency)

### 😨 Anything to be aware of?

- This is a temporary fix, once we add custom network we will need to get the balance directly from the blockchain with the RPC. https://github.com/verida/vault-mobile/issues/1270
