### PR TITLE
Handle migration of persisted wallets for mainnet blockchain networks

### DIFF
--- a/src/api/AccountManager.ts
+++ b/src/api/AccountManager.ts
@@ -146,7 +146,6 @@ class AccountManager extends EventEmitter {
           const network = getNetworkFromDID(selectedAccount.did)
           await this.connect(false, network)
         }
-        await this.restoreUserWallet(true)
       } else {
         store.dispatch(saveUserWallets(wallets))
         store.dispatch(setSelectedWallet(selectedWalletId!))
@@ -633,7 +632,6 @@ class AccountManager extends EventEmitter {
         const network = getNetworkFromDID(did)
         await this.connect(true, network)
       }
-      await this.restoreUserWallet(true)
       DataConnectorsManager.emit('logout', null)
 
       store.dispatch(setSelectedAccount(this.selectedAccount))
@@ -728,7 +726,6 @@ class AccountManager extends EventEmitter {
       store.dispatch(setSelectedAccount(this.selectedAccount))
       store.dispatch(addAccount(this.selectedAccount))
       store.dispatch(fetchAllPublicProfilesData())
-      await this.restoreUserWallet(true)
 
       return this.selectedAccount
     } catch (error) {


### PR DESCRIPTION
### 💭 What's changed?

- Added calling `restoreUserWallet` in the `connect` function, so the crypto wallet are properly refetched and regenerated any time an identity connect.
  - After upgrading the wallet, the identity will connect again as part of the overall initialisation, so the crypto wallet will be updated 

### 🧪 How to test these changes?

- 

### 😨 Anything to be aware of?

- Restoring the wallets at any connection is good for the synchronisation but will degrade slightly the performance
- The persistence of the crypto wallet is not really useful anymore in that case. I haven't removed it though.
