### PR TITLE
Use `AssetType` instead of `AssetId` for coin and token data

### DIFF
--- a/__tests__/cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource.ts
+++ b/__tests__/cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource.ts
@@ -5,7 +5,7 @@ import { AssetIdParams, ChainIdParams } from 'caip'
 import { SupportedBlockchainNamespace } from '../../../src/features/blockchain/@types'
 import {
   AggregateWalletBannerBalance,
-  isAssetIdResourceParams,
+  isAssetTypeResourceParams,
   isChainIdResourceParams,
 } from '../../../src/features/cryptoWallet/@types'
 import { isAggregateWalletBannerBalanceMatchesResource } from '../../../src/features/cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource'
@@ -76,17 +76,17 @@ describe('cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource', () 
     }
 
     expect(isChainIdResourceParams(chainResource)).toBeTruthy()
-    expect(isAssetIdResourceParams(chainResource)).toBeFalsy()
+    expect(isAssetTypeResourceParams(chainResource)).toBeFalsy()
 
     expect(isChainIdResourceParams(assetResource)).toBeFalsy()
-    expect(isAssetIdResourceParams(assetResource)).toBeTruthy()
+    expect(isAssetTypeResourceParams(assetResource)).toBeTruthy()
 
     expect(
       isChainIdResourceParams(AGGREGATE_WALLET_BANNER_BALANCES_USDC.resource)
     ).toBeFalsy()
 
     expect(
-      isAssetIdResourceParams(AGGREGATE_WALLET_BANNER_BALANCES_USDC.resource)
+      isAssetTypeResourceParams(AGGREGATE_WALLET_BANNER_BALANCES_USDC.resource)
     ).toBeTruthy()
 
     expect(
@@ -94,7 +94,7 @@ describe('cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource', () 
     ).toBeTruthy()
 
     expect(
-      isAssetIdResourceParams(AGGREGATE_WALLET_BANNER_BALANCES_ETH.resource)
+      isAssetTypeResourceParams(AGGREGATE_WALLET_BANNER_BALANCES_ETH.resource)
     ).toBeFalsy()
 
     expect(

--- a/src/features/cryptoWallet/@types/index.ts
+++ b/src/features/cryptoWallet/@types/index.ts
@@ -1,5 +1,5 @@
 import BigDecimal from 'bignumber.js'
-import { AccountId, AssetId, AssetIdParams, ChainIdParams } from 'caip'
+import { AccountId, AssetType, AssetTypeParams, ChainIdParams } from 'caip'
 import {
   BlockchainAccount,
   BlockchainNetwork,
@@ -41,7 +41,7 @@ export type CryptoWalletRequest<A extends CryptoWalletRequestAction = 'pay'> = {
 export type BasicTokenData = WithMaybeIcon<{
   name: string
   symbol: string
-  asset: AssetId
+  asset: AssetType
   chainName: ChainNameType
 
   // TODO: Clarify what "cmc" is
@@ -80,7 +80,7 @@ export type BalanceByChainAmount<T extends number = number> = {
 export type BalanceByChainResultData = BalanceByChainAmount & {
   symbol: string
   balance: number
-  asset: AssetId
+  asset: AssetType
   quote: AssetQuote // FIXME: Coming from Wallet Provider, quote is potentially undefined. But this type is not dedicated to the Wallet Provider, it is used elsewhere where quote is required. We should split the type, have a dedicated Wallet Provider type and an internal type on how we want to the data to be.
   token: SupportedTokenObject
 }
@@ -229,18 +229,18 @@ export enum AggregateWalletBannerBalanceType {
 }
 
 // TODO: Move somewhere more general, we do this a lot
-export type ResourceParams = ChainIdParams | AssetIdParams
+export type ResourceParams = ChainIdParams | AssetTypeParams
 
-export function isAssetIdResourceParams(
+export function isAssetTypeResourceParams(
   resourceParams: ResourceParams
-): resourceParams is AssetIdParams {
-  return 'tokenId' in resourceParams && 'assetName' in resourceParams
+): resourceParams is AssetTypeParams {
+  return 'assetName' in resourceParams
 }
 
 export function isChainIdResourceParams(
   resourceParams: ResourceParams
 ): resourceParams is ChainIdParams {
-  return !isAssetIdResourceParams(resourceParams)
+  return !isAssetTypeResourceParams(resourceParams)
 }
 
 type AbstractAggregateWalletBannerBalance<
@@ -274,7 +274,7 @@ export type AggregateWalletBannerBalanceNativeCurrency =
 
 export type AggregateWalletBannerBalanceErc20 =
   AbstractAggregateWalletBannerBalance<
-    AssetIdParams,
+    AssetTypeParams,
     AggregateWalletBannerBalanceType.ERC_20
   >
 

--- a/src/features/cryptoWallet/api/index.ts
+++ b/src/features/cryptoWallet/api/index.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery, retry } from '@reduxjs/toolkit/query/react'
-import { AssetId } from 'caip'
+import { AssetId, AssetType } from 'caip'
 import { config } from 'config'
 import { REHYDRATE } from 'redux-persist'
 
@@ -93,7 +93,10 @@ export const cryptoWalletLegacyApi = createApi({
     //       However, the application can technically enter a state where these values are not
     //       defined.
     getTransactionsForToken: build.query({
-      query: (body: { userAddress: string | null; asset: AssetId | null }) => ({
+      query: (body: {
+        userAddress: string | null
+        asset: AssetType | null
+      }) => ({
         url: 'transaction/list',
         method: 'POST',
         body,
@@ -106,7 +109,7 @@ export const cryptoWalletLegacyApi = createApi({
       query: (body: {
         transactionId: string
         userAddress: string | null | undefined
-        asset: AssetId | null | undefined
+        asset: AssetType | null | undefined
       }) => ({
         url: 'transaction/get',
         method: 'POST',

--- a/src/features/cryptoWallet/hooks/useLazyConfirmTransaction.ts
+++ b/src/features/cryptoWallet/hooks/useLazyConfirmTransaction.ts
@@ -1,4 +1,4 @@
-import { AssetId, ChainId } from 'caip'
+import { AssetType, ChainId } from 'caip'
 import { ethers } from 'ethers'
 import { getMaybeChainMetadatas, useChainMetadatas } from 'features/blockchain'
 import { SupportedBlockchainNamespace } from 'features/blockchain/@types/enums'
@@ -179,7 +179,7 @@ export function useLazyConfirmTransaction(): Stateful<ConfirmTransactionCallback
 
       const { namespace } = chainId
 
-      const maybeErc20Address = new AssetId(resource).assetName?.reference
+      const maybeErc20Address = new AssetType(resource).assetName?.reference
 
       switch (namespace) {
         case SupportedBlockchainNamespace.EIP_155:

--- a/src/features/cryptoWallet/hooks/useMaybeAssetIdForAggregateWalletBannerBalance.ts
+++ b/src/features/cryptoWallet/hooks/useMaybeAssetIdForAggregateWalletBannerBalance.ts
@@ -1,9 +1,9 @@
-import { AssetId, ChainId } from 'caip'
+import { AssetType, ChainId } from 'caip'
 import * as React from 'react'
 
 import {
   AggregateWalletBannerBalance,
-  isAssetIdResourceParams,
+  isAssetTypeResourceParams,
   isChainIdResourceParams,
   ResourceParams,
 } from '../@types'
@@ -11,8 +11,8 @@ import { useBalanceByChainResultsForUniqueWalletAddresses } from './useBalanceBy
 
 // TODO: Move this somewhere.
 const maybeNormalizeResourceParams = (e: ResourceParams) => {
-  if (isAssetIdResourceParams(e)) {
-    const asset = new AssetId(e)
+  if (isAssetTypeResourceParams(e)) {
+    const asset = new AssetType(e)
 
     if (asset.assetName.namespace === 'slip44') return new ChainId(e.chainId)
 
@@ -38,11 +38,11 @@ export function useMaybeAssetIdForAggregateWalletBannerBalance({
     | AggregateWalletBannerBalance
     | null
     | undefined
-}): AssetId | undefined {
+}): AssetType | undefined {
   const { balanceByChainResults } =
     useBalanceByChainResultsForUniqueWalletAddresses()
 
-  return React.useMemo<AssetId | undefined>(() => {
+  return React.useMemo<AssetType | undefined>(() => {
     if (!maybeAggregateWalletBannerBalance) return undefined
 
     const { resource } = maybeAggregateWalletBannerBalance

--- a/src/features/cryptoWallet/hooks/useTransactionsForMaybeAssetId.ts
+++ b/src/features/cryptoWallet/hooks/useTransactionsForMaybeAssetId.ts
@@ -1,16 +1,16 @@
-import { AssetId, ChainId } from 'caip'
+import { AssetType, ChainId } from 'caip'
 import * as React from 'react'
 
 import { useGetTransactionsForTokenQuery } from '../api'
 import { useMaybeSelectedWallet } from './useMaybeSelectedWallet'
 
 export function useTransactionsForMaybeAssetId({
-  assetId: maybeAssetId,
+  assetType: maybeAssetType,
 }: {
-  readonly assetId: AssetId | null | undefined
+  readonly assetType: AssetType | null | undefined
 }) {
-  const chainId = maybeAssetId?.chainId
-    ? new ChainId(maybeAssetId.chainId).toString()
+  const chainId = maybeAssetType?.chainId
+    ? new ChainId(maybeAssetType.chainId).toString()
     : null
 
   const selectedWallet = useMaybeSelectedWallet()
@@ -20,7 +20,7 @@ export function useTransactionsForMaybeAssetId({
     : undefined
 
   const userAddress = account?.address || null
-  const asset = maybeAssetId || null
+  const asset = maybeAssetType || null
 
   const skip = !userAddress || !asset
 

--- a/src/features/cryptoWallet/slice/selectors.ts
+++ b/src/features/cryptoWallet/slice/selectors.ts
@@ -1,4 +1,4 @@
-import { AssetId } from 'caip'
+import { AssetType } from 'caip'
 import {
   BlockchainNetwork,
   BlockchainWalletWithAccounts,
@@ -25,7 +25,7 @@ const createDefaultErrorResponse = (): SelectSingleTokenDataFailureCase => ({
 // TODO: @cawfree If there was a `tokenType` field, it should be created here.
 export const selectSingleTokenData = (
   state: RootState,
-  asset: AssetId | undefined
+  asset: AssetType | undefined
 ): SelectSingleTokenData => {
   if (!asset) return createDefaultErrorResponse()
 
@@ -34,7 +34,9 @@ export const selectSingleTokenData = (
   const { list } = getBalancesData(state, addresses)
 
   const tokenBalance = list?.find((item) => {
-    return new AssetId(item.asset).toString() === new AssetId(asset).toString()
+    return (
+      new AssetType(item.asset).toString() === new AssetType(asset).toString()
+    )
   })
 
   // We should always find a token balance, so this shouldn't happen

--- a/src/features/cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource.ts
+++ b/src/features/cryptoWallet/utils/isAggregateWalletBannerBalanceMatchesResource.ts
@@ -1,8 +1,8 @@
-import { AssetId, ChainId } from 'caip'
+import { AssetType, ChainId } from 'caip'
 
 import {
   AggregateWalletBannerBalance,
-  isAssetIdResourceParams,
+  isAssetTypeResourceParams,
   isChainIdResourceParams,
   ResourceParams,
 } from '../@types'
@@ -24,12 +24,12 @@ export function isAggregateWalletBannerBalanceMatchesResource({
     )
 
   if (
-    isAssetIdResourceParams(maybeMatchingResource) &&
-    isAssetIdResourceParams(resource)
+    isAssetTypeResourceParams(maybeMatchingResource) &&
+    isAssetTypeResourceParams(resource)
   )
     return (
-      new AssetId(maybeMatchingResource).toString() ===
-      new AssetId(resource).toString()
+      new AssetType(maybeMatchingResource).toString() ===
+      new AssetType(resource).toString()
     )
 
   return false

--- a/src/features/cryptoWallet/utils/isNativeToken.ts
+++ b/src/features/cryptoWallet/utils/isNativeToken.ts
@@ -1,4 +1,4 @@
-import { AssetId } from 'caip'
+import { AssetType } from 'caip'
 
-export const isNativeToken = (asset: AssetId) =>
+export const isNativeToken = (asset: AssetType) =>
   asset.assetName.namespace === 'slip44'

--- a/src/pages/Tokens/SingleCurrency.tsx
+++ b/src/pages/Tokens/SingleCurrency.tsx
@@ -65,7 +65,7 @@ const SingleCurrency = () => {
         resource,
       })
     )
-  const assetId = useMaybeAssetIdForAggregateWalletBannerBalance({
+  const assetType = useMaybeAssetIdForAggregateWalletBannerBalance({
     aggregateWalletBannerBalance: maybeAggregateWalletBannerBalance,
   })
 
@@ -96,7 +96,7 @@ const SingleCurrency = () => {
 
   // HACK: We'll only be returning assetIds for resources which the
   //       WalletProvider has an a-priori awareness of.
-  const isAssetSupportedByWalletProvider = Boolean(assetId)
+  const isAssetSupportedByWalletProvider = Boolean(assetType)
 
   const {
     loading: isLoadingTransactions,
@@ -104,7 +104,7 @@ const SingleCurrency = () => {
     transactions,
     error: errorTransactions,
   } = useTransactionsForMaybeAssetId({
-    assetId,
+    assetType,
   })
 
   const error =


### PR DESCRIPTION
Wallet Provider sends coin and token data with an `AssetId` to identify the asset but it should actually be an `AssetType` (to comply with `AssetId` it adds an arbitrary `tokenId: 1`).

In the Wallet, we've been following the structure and used an `AssetId` as well. This PR updates the type and the impacted elements to `AssetType` to be more accurate.

`AssetId` extends `AssetType` and the Wallet never had to use the `tokenId` property, so it's not an issue for the Wallet even if Wallet Provider continues to send an `AssetId` for now.

The other reason for this PR is that Wallet Provider will eventually send an `AssetType` so the sooner the Wallet is ready the better.
