### PR TITLE
Remove Acacia testnet for identity creation and import

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -39,7 +39,6 @@ export const config = {
   },
   features: {
     veridaMainnet: {
-      enabled: true,
       enableMigration: true,
       enableDeletionAfterMigration: true,
     },

--- a/src/features/verida/constants/index.ts
+++ b/src/features/verida/constants/index.ts
@@ -1,5 +1,6 @@
 export const VERIDA_DID_REGEXP =
   /did:vda:(devnet|mainnet|testnet):0x[0-9a-fA-F]{40}/
+// TODO: Update the regex to include Banksia
 
 export enum VeridaMessageType {
   SIMPLE_MESSAGE = 'inbox/type/message',

--- a/src/features/verida/utils/index.ts
+++ b/src/features/verida/utils/index.ts
@@ -55,11 +55,9 @@ export function getDidClientConfigForNetwork(
  */
 export function getSupportedVeridaNetworks(): EnvironmentType[] {
   const networks: EnvironmentType[] = []
-  if (config.features.veridaMainnet.enabled) {
-    networks.push(EnvironmentType.MAINNET)
-  }
 
-  networks.push(EnvironmentType.TESTNET)
+  networks.push(EnvironmentType.MAINNET)
+  // TODO: Add Banksia when available
 
   if (config.dev.devMode) {
     networks.push(EnvironmentType.DEVNET)
@@ -70,8 +68,6 @@ export function getSupportedVeridaNetworks(): EnvironmentType[] {
 
 export function getDefaultVeridaNetwork(): EnvironmentType {
   return config.dev.devMode
-    ? EnvironmentType.DEVNET
-    : config.features.veridaMainnet.enabled
-      ? EnvironmentType.MAINNET
-      : EnvironmentType.TESTNET
+    ? EnvironmentType.DEVNET // TODO: Change to Banksia when available
+    : EnvironmentType.MAINNET
 }


### PR DESCRIPTION
### 💭 What's changed?

- Removed the feature flag to disable the Mainnet as it was more of a kill switch for during the Mainnet launch
- Remove the Acacia testnet from the list of supported Network

### 🧪 How to test these changes?

- Create a new identity and check the testnet is not available anymore
- Import a new identity and check the testnet is not available anymore

### 😨 Anything to be aware of?

- Further work on removing the testnet will be conducted in https://github.com/verida/vault-mobile/pull/1396
- It's only disabling the creation/import. Existing testnet identity in the wallet should continue to work until the Network effectively goes down, from there, the work on https://github.com/verida/vault-mobile/issues/1383 would allow removing them
