### PR TITLE
Fix sending large amount of token failing

### DIFF
--- a/src/features/cryptoWallet/utils/numericAmountToFixedPointCrypto.ts
+++ b/src/features/cryptoWallet/utils/numericAmountToFixedPointCrypto.ts
@@ -1,5 +1,8 @@
-import BigDecimal from 'bignumber.js'
+import BigDecimal from 'bignumber.js' // TODO: Harmonise use of BigNumber between the libraries
 import { BigNumber } from 'ethers'
+
+// Prevent scientific notation, but apparently not gauranteed according to the documentation (https://mikemcl.github.io/bignumber.js/#exponential-at)
+BigDecimal.config({ EXPONENTIAL_AT: 1e9 })
 
 export function numericAmountToFixedPointCrypto({
   amount,
@@ -8,9 +11,11 @@ export function numericAmountToFixedPointCrypto({
   readonly amount: number /* i.e. 0.01 (ETH) */
   readonly decimals: number /* i.e. 18 (ETH) or 6 (USDC) */
 }) {
-  return BigNumber.from(
-    BigDecimal(amount.toFixed(decimals))
-      .multipliedBy(BigDecimal(10).pow(decimals))
-      .toString()
-  )
+  const bigDecimalString = BigDecimal(amount.toFixed(decimals))
+    .multipliedBy(BigDecimal(10).pow(decimals))
+    .toString()
+
+  // BigNumber doesn't like scientific notation, so have to be careful the bigDecimalString isn't one
+  const bigNumber = BigNumber.from(bigDecimalString)
+  return bigNumber
 }


### PR DESCRIPTION
The `toString` method of BigNumber.js was sometimes returning a scientific notation of the number (`"1e+21"`) and sometimes not (`'1000000000'`). That value was then passed to the `BigNumber` from ethers which didn't like the scientific notation and therefore crashed.

### 💭 What's changed?

- Configure BigNumber.js to (try to) avoid scientifica notation. (Note very clear we can avoid it thoug, https://mikemcl.github.io/bignumber.js/#exponential-at)

### 🧪 How to test these changes?

-

### 😨 Anything to be aware of?

-
