### PR TITLE
Fix transaction details screen failing to pass user address in query

### DIFF
--- a/src/pages/Tokens/TransactionDetailsScreen.tsx
+++ b/src/pages/Tokens/TransactionDetailsScreen.tsx
@@ -6,11 +6,10 @@ import LoadingIndicator from '~/components/LoadingIndicator'
 import { TransactionInfo } from '~/components/Tokens'
 import {
   AggregateWalletBannerBalance,
-  getWalletAddressForChainId,
   useChainIdForResourceParams,
   useGetTransactionDetailsQuery,
   useMaybeAssetIdForAggregateWalletBannerBalance,
-  useSelectedMinifiedBlockchainAccounts,
+  useSelectedCryptoWallet,
 } from '~/features/cryptoWallet'
 import { useThemeAwareStyle } from '~/hooks'
 import { MainStackScreenProps } from '~/navigation/types'
@@ -39,11 +38,17 @@ export const TransactionDetailsScreen: React.FC<
   const { id, aggregateWalletBannerBalance } = params
 
   const { resource } = aggregateWalletBannerBalance
+  const resourceChainId = useChainIdForResourceParams({ resource })
 
-  const selectedMinifiedAccounts = useSelectedMinifiedBlockchainAccounts()
-  const chainId = useChainIdForResourceParams({ resource })
-
-  const address = getWalletAddressForChainId(chainId, selectedMinifiedAccounts)
+  // TODO: Factorise this as it's also implemented in TransactionDetails.tsx and SingleCurrency.tsx
+  const selectedCryptoWallet = useSelectedCryptoWallet()
+  const accounts = selectedCryptoWallet?.accounts || []
+  const account = resourceChainId
+    ? accounts.find(
+        (accountItem) => accountItem.namespace === resourceChainId.namespace
+      )
+    : undefined
+  const address = account?.address || null
 
   const maybeAsset = useMaybeAssetIdForAggregateWalletBannerBalance({
     aggregateWalletBannerBalance,


### PR DESCRIPTION
### 💭 What's changed?

- Bring back a piece of code that was lost during a merge:
  - The parallel refacoring of the screens and the crypto wallet led to merge conflicts. One of them, in the `TransactionDetails`/`TransactionDetailsScreen` was incorrectly resolved and used the piece of code before the refactoring, which doesn't work anymore.

### 🧪 How to test these changes?

- Get a wallet with some transactions history and display one of them. 

### 😨 Anything to be aware of?

-
