### PR TITLE
Fix identity creation stuck because of country dropdown

### DIFF
--- a/src/pages/Identity/CreateIdentityScreen.tsx
+++ b/src/pages/Identity/CreateIdentityScreen.tsx
@@ -12,7 +12,9 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
-import PagerView from 'react-native-pager-view'
+import PagerView, {
+  PagerViewOnPageSelectedEvent,
+} from 'react-native-pager-view'
 
 import AccountManager from '~/api/AccountManager'
 import {
@@ -248,6 +250,13 @@ export const CreateIdentityScreen: React.FC<CreateIdentityScreenProps> = (
     pagerRef.current?.setPage(currentPage)
   }, [currentPage])
 
+  const handlSelectedPageChange = useCallback(
+    (event: PagerViewOnPageSelectedEvent) => {
+      setCurrentPage(event.nativeEvent.position)
+    },
+    []
+  )
+
   useEffect(() => {
     if (
       currentPage === PageType.Confirmation &&
@@ -354,6 +363,7 @@ export const CreateIdentityScreen: React.FC<CreateIdentityScreenProps> = (
       <PagerView
         ref={pagerRef}
         initialPage={currentPage}
+        onPageSelected={handlSelectedPageChange}
         scrollEnabled={false}
         style={styles.pager}>
         <View key='name' style={styles.page}>


### PR DESCRIPTION
The PagerView has its own internal state for the different pages and can be controlled by a ref.selectPage() method but the currently selected page is not available so a componnent state is needed. It appears some bug can desynchronise the two "current page" states. There was already a useEffect to update the PagerView selected page from the component state "currentPage". This commit also add a callback to update the component "currentPage" state if the PagerView somehow changed.
